### PR TITLE
Preview improvements

### DIFF
--- a/signal-sticker-tool
+++ b/signal-sticker-tool
@@ -309,12 +309,16 @@ PREVIEW_HTML_DOC = r"""<!DOCTYPE html>
     position: relative;
     display: inline-block;
     padding: 1em;
-    height: auto;
+    height: 128px;
 }
 .sticker .emoji {
     position: absolute;
-    left: 1em;
-    top: 1em;
+    left: 0;
+    top: 0;
+    font-size: 2em;
+}
+img {
+    height: 128px;
 }
   </style>
  </head>
@@ -334,7 +338,8 @@ PREVIEW_HTML_DOC = r"""<!DOCTYPE html>
         var bg_colors = [
             ["White", "#000000", "#ffffff"],
             ["Black", "#ffffff", "#000000"],
-            ["Gray", "#000000","#aaaaaa" ]
+            ["Gray", "#000000","#aaaaaa" ],
+            ["Signal Desktop Dark", "#efefef", "#121212"]
         ];
 
         var color_div = document.getElementById("color-div");


### PR DESCRIPTION
Currently, the size of the stickers will just be the image's intrinsic size. This can be quite large, and hard to skim. This locks it to 128px, a much more comfortable size for any one sticker to be on screen.

Additionally, the emojis are made larger, making them much easier to read; and they're placed slightly outside the bounding box to cover less of the sticker and help ensure the emoji is visible. An example of this:
![The boom emoji over an explosion sticker](https://github.com/ittner/signal-sticker-tool/assets/35016761/d9217f4d-7a4f-47ca-b3fc-970fac32140b)

I also added a color preset for Signal Desktop's dark theme.